### PR TITLE
Update default user voice

### DIFF
--- a/bot/commands/tts_commands.py
+++ b/bot/commands/tts_commands.py
@@ -9,7 +9,7 @@ from bot import user_settings
 from bot.api.tts_handler import text_to_speech
 from bot.user_settings import is_user_voice_exist
 from bot.utils.extract_user_nickname import extract_user_nickname
-from config import GUILD_ID
+from config import GUILD_ID, DEFAULT_VOICE
 from utils.file_utils import list_characters, load_sample_data
 from utils.logger import logger
 
@@ -106,7 +106,7 @@ class TTSCommands(commands.Cog):
         await inter.response.defer(ephemeral=True)
         user_id = inter.author.id
         settings = user_settings.get_user_settings(user_id)
-        character_name = settings.get("selected_sample", "老簡")
+        character_name = settings.get("selected_sample", DEFAULT_VOICE)
 
         if character_name == "自己聲音 (需要先上傳語音樣本）":
             if not is_user_voice_exist(user_id):

--- a/bot/events/message_listener.py
+++ b/bot/events/message_listener.py
@@ -9,7 +9,11 @@ from bot.api.tts_handler import text_to_speech
 from bot.user_settings import is_user_voice_exist
 from bot.utils.extract_user_nickname import extract_user_nickname
 from utils.logger import logger
-from config import TTS_TARGET_CHANNEL_ID, MESSAGE_BOT_TARGET_USER_ID
+from config import (
+    TTS_TARGET_CHANNEL_ID,
+    MESSAGE_BOT_TARGET_USER_ID,
+    DEFAULT_VOICE,
+)
 
 
 class MessageListener(commands.Cog):
@@ -73,7 +77,7 @@ class MessageListener(commands.Cog):
                 logger.info(f"TTS is not enabled for user: {game_username}")
                 return
 
-            character_name = settings.get("selected_sample", "老簡")
+            character_name = settings.get("selected_sample", DEFAULT_VOICE)
 
             if character_name == '自己聲音 (需要先上傳語音樣本）':
                 if not is_user_voice_exist(user_id):

--- a/bot/events/voice_chat_text_channel_listener.py
+++ b/bot/events/voice_chat_text_channel_listener.py
@@ -9,7 +9,7 @@ from bot import user_settings
 from bot.api.tts_handler import text_to_speech
 from bot.user_settings import is_user_voice_exist
 from bot.utils.extract_user_nickname import extract_user_nickname
-from config import VOICE_TEXT_INPUT_CHANNEL_IDS
+from config import VOICE_TEXT_INPUT_CHANNEL_IDS, DEFAULT_VOICE
 from utils.logger import logger
 
 
@@ -56,7 +56,7 @@ class VoiceChatTextChannelListener(commands.Cog):
             logger.info(f"TTS is not enabled for user: {message.author.name}")
             return
 
-        character_name = settings.get("selected_sample", "老簡")
+        character_name = settings.get("selected_sample", DEFAULT_VOICE)
 
         if character_name == '自己聲音 (需要先上傳語音樣本）':
             if not is_user_voice_exist(user_id):

--- a/bot/message_command/play_tts.py
+++ b/bot/message_command/play_tts.py
@@ -9,7 +9,7 @@ from bot.api.tts_handler import text_to_speech
 from bot import user_settings
 from bot.user_settings import is_user_voice_exist
 from bot.utils.extract_user_nickname import extract_user_nickname
-from config import GUILD_ID
+from config import GUILD_ID, DEFAULT_VOICE
 from utils.logger import logger
 
 
@@ -33,7 +33,7 @@ class PlayTTS(commands.Cog):
         user_id = inter.author.id
         settings = user_settings.get_user_settings(user_id)
 
-        character_name = settings.get("selected_sample", "老簡")
+        character_name = settings.get("selected_sample", DEFAULT_VOICE)
 
         if character_name == '自己聲音 (需要先上傳語音樣本）':
             if not is_user_voice_exist(user_id):

--- a/config.py
+++ b/config.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+from utils.file_utils import list_characters, load_sample_data
+
 from google.genai.types import Tool, GoogleSearch, GenerateContentConfig
 
 # Load variables from .env file if it exists
@@ -236,3 +238,6 @@ USER_SETTINGS_FILE = 'data/user_settings.json'
 USER_VOICE_SETTINGS_FILE = 'data/user_voice.json'
 REVERSE_MAPPING_FILE = 'data/game_id_to_user_id.json'
 VOICE_DIR = Path(os.getcwd()).joinpath("data").joinpath("samples")
+
+# Default voice character used when a user has not set a preference
+DEFAULT_VOICE = list_characters(load_sample_data())[0]


### PR DESCRIPTION
## Summary
- provide `DEFAULT_VOICE` in config using the first entry in sample data
- use `DEFAULT_VOICE` as the fallback for user voice across the bot modules

## Testing
- `python -m py_compile config.py bot/events/message_listener.py bot/events/voice_chat_text_channel_listener.py bot/message_command/play_tts.py bot/commands/tts_commands.py`

------
https://chatgpt.com/codex/tasks/task_e_6841d07ba76c83268f469634e9552fb3