### PR TITLE
Add voice character manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
 - `/leave_voice` - Make the bot leave the current voice channel
 - `/tts_start` - Enable TTS functionality
 - `/tts_stop` - Disable TTS functionality
+- `/voice_add` - Add a new voice character (requires manager role)
+- `/voice_remove` - Remove an existing voice character
+- `/voice_edit` - Edit a voice character's audio or reference text
 
 #### Text Commands
 - `!!tts start` - Enable automatic TTS for your messages
@@ -131,11 +134,13 @@ Add new voice characters by:
      }
    }
    ```
+You can also manage voices in Discord using `/voice_add`, `/voice_remove` and `/voice_edit` (requires the role specified by `VOICE_MANAGER_ROLE_ID`).
 
 ### Channel Configuration
 Configure target channels in `config.py`:
 - `TTS_TARGET_CHANNEL_ID`: Channel for message-based TTS
 - `VOICE_TEXT_INPUT_CHANNEL_IDS`: Channels for automatic voice chat TTS
+- `VOICE_MANAGER_ROLE_ID`: Role allowed to add, remove and edit voice characters
 
 ## 🔧 Dependencies
 

--- a/bot/commands/voice_manager.py
+++ b/bot/commands/voice_manager.py
@@ -1,0 +1,169 @@
+import os
+import disnake
+from disnake.ext import commands
+
+from config import GUILD_ID, VOICE_DIR, VOICE_MANAGER_ROLE_ID
+from utils.logger import logger
+from utils.file_utils import (
+    load_sample_data,
+    list_characters,
+    add_character,
+    remove_character,
+    edit_character,
+)
+
+
+class VoiceManager(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.allowed_role = VOICE_MANAGER_ROLE_ID
+
+    def _has_permission(self, member: disnake.Member) -> bool:
+        return any(role.id == self.allowed_role for role in member.roles)
+
+    @commands.slash_command(
+        name="voice_add",
+        guild_ids=[GUILD_ID],
+        description="新增語音角色",
+    )
+    async def voice_add(
+        self,
+        inter: disnake.ApplicationCommandInteraction,
+        character_name: str = commands.Param(name="角色名稱", desc="請輸入角色名稱"),
+        reference_text: str = commands.Param(name="參考文本", desc="TTS 參考文本"),
+        audio: disnake.Attachment = commands.Param(name="語音檔案", desc="上傳語音檔案"),
+    ):
+        if not self._has_permission(inter.author):
+            await inter.response.send_message("你沒有權限使用此命令。", ephemeral=True)
+            return
+        await inter.response.defer(ephemeral=True)
+
+        if not audio.filename.lower().endswith((".wav", ".ogg", ".mp3", ".m4a")):
+            embed = disnake.Embed(
+                title="錯誤",
+                description="請上傳有效的音頻檔案。",
+                color=disnake.Color.red(),
+            )
+            await inter.edit_original_response(embed=embed)
+            return
+
+        dest_path = VOICE_DIR.joinpath(audio.filename)
+        await audio.save(dest_path)
+        try:
+            add_character(character_name, audio.filename, reference_text)
+        except ValueError:
+            dest_path.unlink(missing_ok=True)
+            embed = disnake.Embed(
+                title="錯誤",
+                description="角色已存在。",
+                color=disnake.Color.red(),
+            )
+            await inter.edit_original_response(embed=embed)
+            return
+
+        embed = disnake.Embed(
+            title="成功",
+            description=f"已新增角色 {character_name}",
+            color=disnake.Color.green(),
+        )
+        await inter.edit_original_response(embed=embed)
+        logger.info(f"Added voice character {character_name}")
+
+    @commands.slash_command(
+        name="voice_remove",
+        guild_ids=[GUILD_ID],
+        description="刪除語音角色",
+    )
+    async def voice_remove(
+        self,
+        inter: disnake.ApplicationCommandInteraction,
+        character_name: str = commands.Param(
+            name="角色名稱",
+            desc="選擇要刪除的角色",
+            choices=[disnake.OptionChoice(name=c, value=c) for c in list_characters(load_sample_data())],
+        ),
+    ):
+        if not self._has_permission(inter.author):
+            await inter.response.send_message("你沒有權限使用此命令。", ephemeral=True)
+            return
+        await inter.response.defer(ephemeral=True)
+        try:
+            entry = remove_character(character_name)
+            file_path = VOICE_DIR.joinpath(entry["file"])
+            if file_path.exists():
+                file_path.unlink()
+            embed = disnake.Embed(
+                title="成功",
+                description=f"已刪除角色 {character_name}",
+                color=disnake.Color.green(),
+            )
+            logger.info(f"Removed voice character {character_name}")
+        except ValueError:
+            embed = disnake.Embed(
+                title="錯誤",
+                description="角色不存在。",
+                color=disnake.Color.red(),
+            )
+        await inter.edit_original_response(embed=embed)
+
+    @commands.slash_command(
+        name="voice_edit",
+        guild_ids=[GUILD_ID],
+        description="編輯語音角色",
+    )
+    async def voice_edit(
+        self,
+        inter: disnake.ApplicationCommandInteraction,
+        character_name: str = commands.Param(
+            name="角色名稱",
+            desc="選擇要編輯的角色",
+            choices=[disnake.OptionChoice(name=c, value=c) for c in list_characters(load_sample_data())],
+        ),
+        reference_text: str = commands.Param(
+            name="參考文本", desc="新的參考文本（留空則不修改）", default=None
+        ),
+        audio: disnake.Attachment = commands.Param(
+            name="語音檔案", desc="新的語音檔案（可選）", default=None
+        ),
+    ):
+        if not self._has_permission(inter.author):
+            await inter.response.send_message("你沒有權限使用此命令。", ephemeral=True)
+            return
+        await inter.response.defer(ephemeral=True)
+
+        filename = None
+        if audio:
+            if not audio.filename.lower().endswith((".wav", ".ogg", ".mp3", ".m4a")):
+                embed = disnake.Embed(
+                    title="錯誤",
+                    description="請上傳有效的音頻檔案。",
+                    color=disnake.Color.red(),
+                )
+                await inter.edit_original_response(embed=embed)
+                return
+            dest_path = VOICE_DIR.joinpath(audio.filename)
+            await audio.save(dest_path)
+            filename = audio.filename
+
+        try:
+            edit_character(character_name, filename=filename, text=reference_text)
+            embed = disnake.Embed(
+                title="成功",
+                description=f"已更新角色 {character_name}",
+                color=disnake.Color.green(),
+            )
+            logger.info(f"Edited voice character {character_name}")
+        except ValueError:
+            if filename:
+                VOICE_DIR.joinpath(filename).unlink(missing_ok=True)
+            embed = disnake.Embed(
+                title="錯誤",
+                description="角色不存在。",
+                color=disnake.Color.red(),
+            )
+
+        await inter.edit_original_response(embed=embed)
+
+
+def setup(bot: commands.Bot):
+    bot.add_cog(VoiceManager(bot))

--- a/config.py
+++ b/config.py
@@ -15,6 +15,11 @@ load_dotenv()
 DISCORD_TOKEN = environ.get('DISCORD_TOKEN')
 TTS_API_URL = 'http://127.0.0.1:9880/tts/'
 GUILD_ID = int(environ.get('GUILD_ID')) if 'GUILD_ID' in environ else 933290709589577728
+VOICE_MANAGER_ROLE_ID = (
+    int(environ.get("VOICE_MANAGER_ROLE_ID"))
+    if "VOICE_MANAGER_ROLE_ID" in environ
+    else 1003708775284342955
+)
 LOGGER_LEVEL = logging.DEBUG
 
 QUESTION_PROMPT = """你是一個樂於助人的小妖精，總是以積極和善的態度回答問題。

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -77,3 +77,46 @@ def save_user_conversation(user_id: int, conversation: list):
     """
     with open(f"data/conversations/{user_id}.json", "w", encoding="utf-8") as f:
         json.dump(conversation, f, ensure_ascii=False, indent=4)
+
+
+def save_sample_data(data: dict, file_path: str = "data/sample_data.json") -> None:
+    """保存語音樣本數據到文件"""
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=4)
+
+
+def add_character(name: str, filename: str, text: str, file_path: str = "data/sample_data.json") -> None:
+    """新增語音角色"""
+    data = load_sample_data(file_path)
+    if name in data:
+        raise ValueError("character already exists")
+    data[name] = {"file": filename, "text": text}
+    save_sample_data(data, file_path)
+
+
+def remove_character(name: str, file_path: str = "data/sample_data.json") -> dict:
+    """刪除語音角色並返回其內容"""
+    data = load_sample_data(file_path)
+    if name not in data:
+        raise ValueError("character not found")
+    entry = data.pop(name)
+    save_sample_data(data, file_path)
+    return entry
+
+
+def edit_character(
+    name: str,
+    *,
+    filename: str | None = None,
+    text: str | None = None,
+    file_path: str = "data/sample_data.json",
+) -> None:
+    """編輯語音角色信息"""
+    data = load_sample_data(file_path)
+    if name not in data:
+        raise ValueError("character not found")
+    if filename:
+        data[name]["file"] = filename
+    if text:
+        data[name]["text"] = text
+    save_sample_data(data, file_path)


### PR DESCRIPTION
## Summary
- enable editing of sample_data.json via new commands
- add `/voice_add`, `/voice_remove` and `/voice_edit`
- document new commands and mention Discord management option
- manager role is now configurable via `VOICE_MANAGER_ROLE_ID`

## Testing
- `python -m py_compile utils/file_utils.py bot/commands/voice_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6841d39d7f3c8326a7df4712ae8834a6