### PR TITLE
Fix insecure temporary file usage

### DIFF
--- a/bot/commands/llm_commands.py
+++ b/bot/commands/llm_commands.py
@@ -80,7 +80,9 @@ class LLMCommands(commands.Cog):
             return
 
         if image:
-            image_path: os.PathLike = Path(tempfile.mktemp(suffix=".png"))
+            fd, temp_path = tempfile.mkstemp(suffix=".png")
+            os.close(fd)
+            image_path: os.PathLike = Path(temp_path)
 
             await image.save(image_path)
 


### PR DESCRIPTION
## Summary
- prevent insecure temp file creation when saving image attachments

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6841de0d61388326a5920a3f7811e48c